### PR TITLE
Correct Object.assign, Add alternatives header?

### DIFF
--- a/questions/clone-object.md
+++ b/questions/clone-object.md
@@ -12,16 +12,16 @@ const shallowClone = { ...obj };
 
 With this technique, prototypes are ignored. In addition, nested objects are not cloned, but rather their references get copied, so nested objects still refer to the same objects as the original. Deep-cloning is much more complex in order to effectively clone any type of object (Dates, RegExp, Function, Set, etc) that may be nested within the object.
 
+Other alternative include
+
+* `JSON.stringify()` but has the drawback that it is CPU-intensive.
+* `Object.assign({},obj)` is another alternative.
+* `Object.keys(obj).reduce((acc, key) => acc[key] = obj[key], acc , {})` is another more verbose alternative that shows the concept in greater depth.
+
 #### Good to hear
 
 * JavaScript passes objects by reference, meaning that nested objects get their references copied, instead of their values.
 * The same method can be used to merge two objects.
-
-#### Alternatives
-
-* `JSON.stringify()` is another alternative, but is CPU-intensive.
-* `Object.assign({},obj)` is another alternative.
-* `Object.keys(obj).reduce((acc, key) => acc[key] = obj[key], acc , {})` is another more verbose alternative that shows the concept in greater depth.
 
 ##### Additional links
 


### PR DESCRIPTION
I'm pretty sure Good to Hear should have the alternatives in it, those should be a separate area.

I've also added a correct Object.assign example, and the more verbose reduction closure however I have skipped the longer iterator(for loop) answer because of the implicit iterator in the reduce example showing the same concept in a more compact form