### PR TITLE
Use closest instead of matches for event delegation

### DIFF
--- a/questions/event-delegation.md
+++ b/questions/event-delegation.md
@@ -14,8 +14,8 @@ This provides two main benefits:
 Instead of:
 
 ```js
-document.querySelectorAll("span").forEach(span => {
-  span.addEventListener("click", handleSpanClick)
+document.querySelectorAll("button").forEach(button => {
+  button.addEventListener("click", handleButtonClick)
 })
 ```
 
@@ -23,8 +23,8 @@ Event delegation involves using a condition to ensure the child target matches o
 
 ```js
 document.addEventListener("click", e => {
-  if (e.target.matches("span")) {
-    handleSpanClick()
+  if (e.target.closest("button")) {
+    handleButtonClick()
   }
 })
 ```

--- a/questions/short-circuit-evaluation.md
+++ b/questions/short-circuit-evaluation.md
@@ -44,16 +44,16 @@ Another common use case is only evaluating an expression if the first operand is
 ```js
 // Instead of:
 addEventListener("click", e => {
-  if (e.target.matches("span")) {
-    handleSpanClick(e)
+  if (e.target.closest("button")) {
+    handleButtonClick(e)
   }
 })
 
 // You can take advantage of short-circuit evaluation:
-addEventListener("click", e => e.target.matches("span") && handleSpanClick(e))
+addEventListener("click", e => e.target.closest("button") && handleButtonClick(e))
 ```
 
-In the above case, if `e.target` does not match the `"span"` selector, the function will not be called. This is because the first operand will be falsy, causing the second operand to not be evaluated.
+In the above case, if `e.target` is not or does not contain an element matching the `"button"` selector, the function will not be called. This is because the first operand will be falsy, causing the second operand to not be evaluated.
 
 #### Good to hear
 


### PR DESCRIPTION
## Description

The event delegation examples could encourage better practices and protect against a very common mistake in event delegation.

This PR changes the element being delegated from a span, which is not normally a clickable element, to a button, which is normally a clickable element and is naturally accessible.

This PR also changes how delegated targets are detected. Consider that the delegated target may contain child elements, such as a button containing an svg, span, or strong element. For example, `target.matches('button')` would fail to detect a button if an svg within that button was clicked, while `target.closest('button')` would correctly detect the button. And if the button did not contain children, then `target.closest('button')` would still correctly detect the button.

This project looks really fun. Thanks for creating it!

## What does your PR belong to?

* [x] Questions / Answers
* [x] Website
* [ ] General / Things regarding the repository (like CI Integration)

I think its Questions / Answers, but they’re seen on the website. (Perhaps CONTRIBUTING.md could be more clarifying about this.)

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (non-breaking improvement of a question)

This is safely an enhancement, but it might be a bug fix. You decide, because the existing span examples did not account for scenarios where a delegated span had children.

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have checked that the changes are working properly
* [x] I have checked that there isn't any PR doing the same
* [x] I have read the **CONTRIBUTING** document.
